### PR TITLE
Fix: Handle log(1 - p) edge case in getlog_complement_doubleMatrix to…

### DIFF
--- a/src/matrices.cpp
+++ b/src/matrices.cpp
@@ -224,7 +224,7 @@ double** getlog_doubleMatrix(double** matrix, int n, int m){
 double** getlog_complement_doubleMatrix(double** matrix, int n, int m){
 
     double** logcompmatrix = allocate_doubleMatrix(n, m);     // allocate
-    const double epsilon = 1e-6;  // Small value to clamp just below 1.0
+    const double epsilon = std::numeric_limits<double>::epsilon();  // Smallest possible double
 
     for (int i=0; i<n; ++i)             // initialize
     {

--- a/src/matrices.cpp
+++ b/src/matrices.cpp
@@ -224,12 +224,17 @@ double** getlog_doubleMatrix(double** matrix, int n, int m){
 double** getlog_complement_doubleMatrix(double** matrix, int n, int m){
 
     double** logcompmatrix = allocate_doubleMatrix(n, m);     // allocate
+    const double epsilon = 1e-6;  // Small value to clamp just below 1.0
 
     for (int i=0; i<n; ++i)             // initialize
     {
         for (int j=0; j<m; ++j)
         {
-            logcompmatrix[i][j] = log(1-matrix[i][j]);
+	  double value = matrix[i][j];
+	  if (value == 1.0){
+	    value = 1.0 - epsilon;
+	  }
+	  logcompmatrix[i][j] = log(1 - value);
         }
     }
     return logcompmatrix;


### PR DESCRIPTION
… prevent -inf errors

- Added a check in  to clamp mutation probability values of 1.0 to slightly below 1.0, ensuring that  calculations do not evaluate to -inf.